### PR TITLE
Add tokenize() with support for quotes, operators and words

### DIFF
--- a/include/minishell.h
+++ b/include/minishell.h
@@ -30,12 +30,18 @@ typedef struct s_token
 	struct s_token	*next;
 }	t_token;
 
-// Prototypes fonctions pour (tokenize)
+// Prototypes fonctions pour (tokenizer)
 t_token			*tokenize(char *input);
+int				is_space(char c);
 void			add_token(t_token **list, char *value, t_token_type type);
+t_token			*new_token(char *value, t_token_type type);
 t_token_type	get_operator_type(char *str);
 int				operator_length(char *str);
-void	ft_getcwd(void);
-void	ft_read_line(char **envp);
-char *ft_path_finder(char *cmd);
+int				handle_operator(t_token **tokens, char *input);
+int				handle_word(t_token **tokens, char *input);
+int				handle_quotes(t_token **tokens, char *input);
+
+void			ft_getcwd(void);
+void			ft_read_line(char **envp);
+char			*ft_path_finder(char *cmd);
 #endif

--- a/source/ft_read_line.c
+++ b/source/ft_read_line.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   ft_read_line.c                                     :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: jiparcer <jiparcer@student.42.fr>          +#+  +:+       +#+        */
+/*   By: lsadikaj <lsadikaj@student.42lausanne.ch>  +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/03/24 14:42:25 by jiparcer          #+#    #+#             */
-/*   Updated: 2025/03/24 16:18:11 by jiparcer         ###   ########.fr       */
+/*   Updated: 2025/03/24 19:20:05 by lsadikaj         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -14,10 +14,15 @@
 
 void	ft_read_line2(char *input, char **envp)
 {
-	int status;
-	pid_t pid;
-	char **cmd;
+	int 	status;
+	pid_t	pid;
+	char	**cmd;
+	t_token	*tokens;
 
+	// Tokenisation de l'entrée utilisateur
+	tokens = tokenize(input);
+	// TODO: remplacer ft_split() par tokenize() dans l'exécution future
+	
 	cmd = ft_split(input, ' ');
 	pid = fork(); //! je suis pas encore sûr
 	if(pid == 0)

--- a/source/tokenizer/tokenizer.c
+++ b/source/tokenizer/tokenizer.c
@@ -6,17 +6,19 @@
 /*   By: lsadikaj <lsadikaj@student.42lausanne.ch>  +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/03/24 13:37:41 by lsadikaj          #+#    #+#             */
-/*   Updated: 2025/03/24 16:31:40 by lsadikaj         ###   ########.fr       */
+/*   Updated: 2025/03/24 19:22:17 by lsadikaj         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
-#include "../include/minishell.h"
+#include "../../include/minishell.h"
 
+// Check if a character is a space or tab
 int	is_space(char c)
 {
 	return (c == ' ' || c == '\t');
 }
 
+// Calculates the length of a word (non-espace characters)
 static int	word_len(char *str)
 {
 	int	len;
@@ -27,36 +29,30 @@ static int	word_len(char *str)
 	return (len);
 }
 
+// Tokenizes the input line into a linked list of tokens
 t_token	*tokenize(char *input)
 {
-	t_token			*tokens = NULL;
+	t_token			*tokens;
 	int				i;
-	int				len;
-	char			*word;
-	t_token_type	type;
+	int				ret;
 
+	tokens = NULL;
 	i = 0;
 	while (input[i])
 	{
 		if (is_space(input[i]))
 			i++;
-		else if (input[i] == '|' || input[i] == '<' || input[i] == '>')
+		else if (is_operator(&input[i]))
+			i += handle_operator(&tokens, &input[i]);
+		else if (input[i] == '"' || input[i] == '\'')
 		{
-			len = operator_length(&input[i]);
-			word = ft_substr(input, i, len);
-			type = get_operator_type(&input[i]);
-			add_token(&tokens. word, type);
-			free(word);
-			i += len;
+			ret = handle_quotes(&tokens, &input[i]);
+			if (ret == -1)
+				return (NULL);
+			i += ret;
 		}
 		else
-		{
-			len = word_len(&input[i]);
-			word = ft_substr(input, i, len);
-			add_token(&tokens, word, TOKEN_WORD);
-			free(word);
-			i += len;
-		}
+			i += handle_word(&tokens, &input[i]);
 	}
 	return (tokens);
 }

--- a/source/tokenizer/tokenizer_handle.c
+++ b/source/tokenizer/tokenizer_handle.c
@@ -1,0 +1,76 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   tokenizer_handle.c                                 :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: lsadikaj <lsadikaj@student.42lausanne.ch>  +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2025/03/24 17:21:49 by lsadikaj          #+#    #+#             */
+/*   Updated: 2025/03/24 19:27:36 by lsadikaj         ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include "../../include/minishell.h"
+
+// Handles operator token (|, >, >>, <, <<) and adds it to the token list
+int	handle_operator(t_token **tokens, char *input)
+{
+	int				len;
+	char			*op;
+	t_token_type	type;
+
+	len = operator_length(input);
+	op = ft_substr(input, 0, len);
+	type = get_operator_type(input);
+	add_token(tokens, op, type);
+	free(op);
+	return (len);
+}
+
+// Handles a plain word and adds it to the token list
+int	handle_word(t_token **tokens, char *input)
+{
+	int		len;
+	char	*word;
+
+	len = 0;
+	while (input[len])
+	{
+		if (input[len] == ' ' || input[len] == '\t')
+			break ;
+		if (input[len] == '|' || input[len] == '<' || input[len] == '>')
+			break ;
+		if (input[len] == '\'' || input[len] == '"')
+			break ;
+		len++;
+	}
+	word = ft_substr(input, 0, len);
+	add_token(tokens. word, TOKEN_WORD);
+	free(word);
+	return (len);
+}
+
+// Handles a quoted string and adds it to the token list
+int	handle_quotes(t_token **tokens, char *input)
+{
+	char	quote;
+	int		len;
+	char	*word;
+
+	quote = input[0];
+	len = 1;
+	while (input[len] && input[len] != quote)
+		len++;
+	if (input[len] == quote)
+	{
+		word = ft_substr(input + 1, 0, len - 1);
+		add_token(tokens, word, TOKEN_WORD);
+		free(word);
+		return (len + 1);
+	}
+	else
+	{
+		ft_printf("minishell: syntax error: unclosed quote\n");
+		return (-1);
+	}
+}

--- a/source/tokenizer/tokenizer_utils.c
+++ b/source/tokenizer/tokenizer_utils.c
@@ -6,12 +6,13 @@
 /*   By: lsadikaj <lsadikaj@student.42lausanne.ch>  +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/03/24 15:58:03 by lsadikaj          #+#    #+#             */
-/*   Updated: 2025/03/24 16:31:43 by lsadikaj         ###   ########.fr       */
+/*   Updated: 2025/03/24 19:29:36 by lsadikaj         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
-#include "../include/minishell.h"
+#include "../../include/minishell.h"
 
+// Allocates and initializes a new token
 t_token	*new_token(char *value, t_token_type type)
 {
 	t_token	*token;
@@ -25,6 +26,7 @@ t_token	*new_token(char *value, t_token_type type)
 	return (token);
 }
 
+// Appends a new token to the end of the token list
 void	add_token(t_token **list, char *value, t_token_type type)
 {
 	t_token	*new;
@@ -61,7 +63,7 @@ t_token_type	get_operator_type(char *str)
 		return (TOKEN_REDIRECT_OUT);
 	else if (str[0] == '<' && str[1] == '<')
 		return (TOKEN_HEREDOC);
-	else if (str[0] = '<' && str[0] != '<')
+	else if (str[0] == '<' && str[1] != '<')
 		return (TOKEN_REDIRECT_IN);
 	else if (str[0] == '|')
 		return (TOKEN_PIPE);


### PR DESCRIPTION
Cette pull request ajoute une implémentation complète de la fonction `tokenize()` pour effectuer l’analyse lexicale de l’entrée utilisateur.

✅ Fonctionnalités :
- Découpe l'entrée utilisateur en tokens (stockés dans une liste chaînée `t_token`)
- Détection et classification des éléments suivants :
  - **Mots simples**
  - **Chaînes entre guillemets** (`"..."` et `'...'`)
  - **Opérateurs shell** (`|`, `<`, `<<`, `>`, `>>`)
- Gestion des **quotes non fermées** avec affichage d’un message d’erreur

Concernant l'ajout dans la fonction ft_read_line2() dans le fichier ft_read_line.c :
🔄 Actuellement :
- On utilise encore `ft_split()` pour exécuter les commandes (via `execve`) pour ne pas casser le code en place
- La fonction `tokenize()` est uniquement appelée et stocke les tokens (prête à être utilisée plus tard dans un AST ou une exécution directe)

🧪 Le code est conforme à la norme 42 et organisé dans le dossier `source/tokenizer/`
