### PR TITLE
Ajout du tokenizer et du parser (gestion opérateurs, AST, guillemets doubles)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,15 @@
+# **************************************************************************** #
+#                                                                              #
+#                                                         :::      ::::::::    #
+#    Makefile                                           :+:      :+:    :+:    #
+#                                                     +:+ +:+         +:+      #
+#    By: lsadikaj <lsadikaj@student.42lausanne.ch>  +#+  +:+       +#+         #
+#                                                 +#+#+#+#+#+   +#+            #
+#    Created: 2025/03/25 14:00:24 by lsadikaj          #+#    #+#              #
+#    Updated: 2025/03/26 15:44:40 by lsadikaj         ###   ########.fr        #
+#                                                                              #
+# **************************************************************************** #
+
 # Nom de l'exécutable
 NAME = minishell
 
@@ -13,34 +25,42 @@ INC_DIR = include
 LIBFT_DIR = libft
 LIBFT = $(LIBFT_DIR)/libft.a
 
-# Fichiers sources et objets
-SRCS = $(wildcard $(SRC_DIR)/*.c)
+# Fichiers source
+SRCS = \
+	$(SRC_DIR)/ft_getcwd.c \
+	$(SRC_DIR)/ft_is_builtin.c \
+	$(SRC_DIR)/ft_path_finder.c \
+	$(SRC_DIR)/ft_read_line.c \
+	$(SRC_DIR)/tokenizer/tokenizer.c \
+	$(SRC_DIR)/tokenizer/tokenizer_utils.c \
+	$(SRC_DIR)/tokenizer/tokenizer_handle.c \
+	$(SRC_DIR)/parser/parser.c \
+	$(SRC_DIR)/parser/parser_utils.c
+
+# Fichiers objets
 OBJS = $(SRCS:$(SRC_DIR)/%.c=$(OBJ_DIR)/%.o)
 
-# Options d'inclusion de headers
-INCLUDES = -I$(INC_DIR)
-
-# Règle par défaut
-all: $(NAME)
+# Compilation des fichiers objets dans les sous-dossiers
+$(OBJ_DIR)/%.o: $(SRC_DIR)/%.c
+	@mkdir -p $(dir $@)
+	$(CC) $(CFLAGS) -I$(INC_DIR) -c $< -o $@
 
 # Compilation de l'exécutable
 $(NAME): $(OBJS)
 	make -C $(LIBFT_DIR)
 	$(CC) $(CFLAGS) $(OBJS) $(LIBFT) $(LDFLAGS) -o $(NAME)
 
-# Compilation des objets
-$(OBJ_DIR)/%.o: $(SRC_DIR)/%.c
-	@mkdir -p $(OBJ_DIR)
-	$(CC) $(CFLAGS) $(INCLUDES) -c $< -o $@
+# Règle principale
+all: $(NAME)
 
 # Nettoyage
 clean:
 	rm -rf $(OBJ_DIR)
-	make clean -C $(LIBFT_DIR)
+	make -C $(LIBFT_DIR) clean
 
 fclean: clean
 	rm -f $(NAME)
-	make fclean -C $(LIBFT_DIR)
+	make -C $(LIBFT_DIR) fclean
 
 re: fclean all
 

--- a/include/minishell.h
+++ b/include/minishell.h
@@ -1,5 +1,5 @@
-#ifndef SHELL_H
-# define SHELL_H
+#ifndef MINISHELL_H
+# define MINISHELL_H
 
 # include <stdio.h>
 # include <stdlib.h>
@@ -20,7 +20,9 @@ typedef enum e_token_type
 	TOKEN_REDIRECT_IN,
 	TOKEN_REDIRECT_OUT,
 	TOKEN_APPEND,
-	TOKEN_HEREDOC
+	TOKEN_HEREDOC,
+	TOKEN_AND,
+	TOKEN_OR,
 }	t_token_type;
 
 typedef struct s_token
@@ -30,9 +32,36 @@ typedef struct s_token
 	struct s_token	*next;
 }	t_token;
 
-// Prototypes fonctions pour (tokenizer)
+typedef enum e_node_type
+{
+	NODE_CMD,
+	NODE_PIPE,
+	NODE_REDIRECT_IN,
+	NODE_REDIRECT_OUT,
+	NODE_APPEND,
+	NODE_HEREDOC,
+	NODE_AND,
+	NODE_OR
+}	t_node_type;
+
+typedef struct s_node
+{
+	t_node_type		type;
+	char			**cmd;
+	struct s_node	*left;
+	struct s_node	*right;
+}	t_node;
+
+// Prototypes initialisation
+void			ft_getcwd(void);
+void			ft_read_line(char **envp);
+char			*ft_path_finder(char *cmd);
+int				ft_is_builtin(char *cmd, char **envp);
+
+// Prototypes (tokenizer)
 t_token			*tokenize(char *input);
 int				is_space(char c);
+int				is_operator_str(char *str);
 void			add_token(t_token **list, char *value, t_token_type type);
 t_token			*new_token(char *value, t_token_type type);
 t_token_type	get_operator_type(char *str);
@@ -41,7 +70,12 @@ int				handle_operator(t_token **tokens, char *input);
 int				handle_word(t_token **tokens, char *input);
 int				handle_quotes(t_token **tokens, char *input);
 
-void			ft_getcwd(void);
-void			ft_read_line(char **envp);
-char			*ft_path_finder(char *cmd);
+// Prototypes (parser)
+t_node			*parse_ast(t_token *tokens);
+int    			find_lowest_priority(t_token *tokens);
+t_node			*create_cmd_node(t_token *tokens);
+char			**fill_cmd_array(t_token *tokens, int count);
+int				count_words(t_token *tokens);
+t_node_type		token_to_node_type(t_token_type token_type);
+
 #endif

--- a/source/ft_read_line.c
+++ b/source/ft_read_line.c
@@ -6,7 +6,7 @@
 /*   By: lsadikaj <lsadikaj@student.42lausanne.ch>  +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/03/24 14:42:25 by jiparcer          #+#    #+#             */
-/*   Updated: 2025/03/24 19:20:05 by lsadikaj         ###   ########.fr       */
+/*   Updated: 2025/03/26 15:56:41 by lsadikaj         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -17,18 +17,22 @@ void	ft_read_line2(char *input, char **envp)
 	int 	status;
 	pid_t	pid;
 	char	**cmd;
-	t_token	*tokens;
 
-	// Tokenisation de l'entrée utilisateur
-	tokens = tokenize(input);
-	// TODO: remplacer ft_split() par tokenize() dans l'exécution future
+/* ==========================================================================
+		TODO : à remplacer plus tard par la construction de l’AST :
+
+			t_token *tokens = tokenize(input);
+			t_node  *ast    = parse_ast(tokens);
+
+		=> Puis on exécutera à partir de l’arbre (et non plus avec ft_split)
+	========================================================================== */
 	
 	cmd = ft_split(input, ' ');
 	pid = fork(); //! je suis pas encore sûr
 	if(pid == 0)
 	{	
 		//! A CHANGER PAR ALGO QUI TEST TOUT LES PATHS //   pour l instant fonctionne uniquement avec les fonction du path: "/bin/"
-		if((ft_is_bultin(cmd[0]) == 0))
+		if((ft_is_builtin(cmd[0], envp) == 0))
 		{
 			execve(ft_path_finder(input) , cmd ,envp);
 			perror("execve");

--- a/source/parser/parser.c
+++ b/source/parser/parser.c
@@ -1,0 +1,102 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   parser.c                                           :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: lsadikaj <lsadikaj@student.42lausanne.ch>  +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2025/03/26 12:33:46 by lsadikaj          #+#    #+#             */
+/*   Updated: 2025/03/26 15:33:34 by lsadikaj         ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include "../../include/minishell.h"
+
+// Renvoie la priorité d’un type de token (plus petit = plus prioritaire)
+static int	get_priority(t_token_type type)
+{
+	if (type == TOKEN_OR)
+		return (1);
+	if (type == TOKEN_AND)
+		return (2);
+	if (type == TOKEN_PIPE)
+		return (3);
+	if (type == TOKEN_REDIRECT_OUT || type == TOKEN_REDIRECT_IN
+		|| type == TOKEN_APPEND || type == TOKEN_HEREDOC)
+		return (4);
+	return (100);
+}
+
+// Renvoie la position du token ayant la plus faible priorité
+int	find_lowest_priority(t_token *tokens)
+{
+	int			pos;
+	int			i;
+	int			lowest;
+	t_token		*tmp;
+
+	pos = -1;
+	i = 0;
+	lowest = 100;
+	tmp = tokens;
+	while (tmp)
+	{
+		if (get_priority(tmp->type) < lowest)
+		{
+			lowest = get_priority(tmp->type);
+			pos = i;
+		}
+		tmp = tmp->next;
+		i++;
+	}
+	return (pos);
+}
+
+// Renvoie le pointeur vers le token à une position donnée
+static t_token	*get_token_at(t_token *tokens, int pos)
+{
+	int	i;
+
+	i = 0;
+	while (tokens)
+	{
+		if (i == pos)
+			return (tokens);
+		tokens = tokens->next;
+		i++;
+	}
+	return (NULL);
+}
+
+// Construit l’arbre de syntaxe (AST) à partir des tokens
+t_node	*parse_ast(t_token *tokens)
+{
+	t_token	*op;
+	t_node	*node;
+	t_token	*tmp;
+	int		i;
+
+	if (!tokens)
+		return (NULL);
+	if (!tokens->next)
+		return (create_cmd_node(tokens));
+	i = find_lowest_priority(tokens);
+	op = get_token_at(tokens, i);
+	if (!op || i == -1)
+		return (create_cmd_node(tokens));
+	tmp = tokens;
+	while (--i > 0 && tmp)
+		tmp = tmp->next;
+	if (!tmp || !tmp->next || !tmp->next->next)
+		return (NULL);
+	op = tmp->next;
+	tmp->next = NULL;
+	node = malloc(sizeof(t_node));
+	if (!node)
+		return (NULL);
+	node->type = token_to_node_type(op->type);
+	node->cmd = NULL;
+	node->left = parse_ast(tokens);
+	node->right = parse_ast(op->next);
+	return (node);
+}

--- a/source/parser/parser_utils.c
+++ b/source/parser/parser_utils.c
@@ -1,0 +1,107 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   parser_utils.c                                     :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: lsadikaj <lsadikaj@student.42lausanne.ch>  +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2025/03/26 15:21:00 by lsadikaj          #+#    #+#             */
+/*   Updated: 2025/03/26 15:33:40 by lsadikaj         ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include "../../include/minishell.h"
+
+// Traduit un token type en node type pour l’AST
+t_node_type	token_to_node_type(t_token_type token_type)
+{
+	if (token_type == TOKEN_PIPE)
+		return (NODE_PIPE);
+	else if (token_type == TOKEN_AND)
+		return (NODE_AND);
+	else if (token_type == TOKEN_OR)
+		return (NODE_OR);
+	else if (token_type == TOKEN_REDIRECT_OUT)
+		return (NODE_REDIRECT_OUT);
+	else if (token_type == TOKEN_REDIRECT_IN)
+		return (NODE_REDIRECT_IN);
+	else if (token_type == TOKEN_APPEND)
+		return (NODE_APPEND);
+	else if (token_type == TOKEN_HEREDOC)
+		return (NODE_HEREDOC);
+	return (NODE_CMD);
+}
+
+// Compte le nombre de TOKEN_WORD dans la liste
+int	count_words(t_token *tokens)
+{
+	int	count = 0;
+
+	while (tokens && tokens->type == TOKEN_WORD)
+	{
+		count++;
+		tokens = tokens->next;
+	}
+	return (count);
+}
+
+// Alloue et remplit le tableau de cmd[] avec les valeurs des tokens
+char	**fill_cmd_array(t_token *tokens, int count)
+{
+	char	**cmd;
+	int		i;
+
+	cmd = ft_calloc(count + 1, sizeof(char *));
+	if (!cmd)
+		return (NULL);
+	i = 0;
+	while (i < count && tokens && tokens->type == TOKEN_WORD)
+	{
+		if (!tokens->value)
+		{
+			while (--i >= 0)
+				free(cmd[i]);
+			free(cmd);
+			return (NULL);
+		}
+		cmd[i] = ft_strdup(tokens->value);
+		if (!cmd[i])
+		{
+			while (--i >= 0)
+				free(cmd[i]);
+			free(cmd);
+			return (NULL);
+		}
+		tokens = tokens->next;
+		i++;
+	}
+	cmd[i] = NULL;
+	return (cmd);
+}
+
+// Crée un nœud de type NODE_CMD à partir des tokens
+t_node	*create_cmd_node(t_token *tokens)
+{
+	t_node	*node;
+	int		count;
+	t_token	*tmp;
+
+	if (!tokens)
+		return (NULL);
+	tmp = tokens;
+	while (tmp)
+		tmp = tmp->next;
+	count = count_words(tokens);
+	if (count <= 0)
+		return (NULL);
+	node = ft_calloc(1, sizeof(t_node));
+	if (!node)
+		return (NULL);
+	node->type = NODE_CMD;
+	node->left = NULL;
+	node->right = NULL;
+	node->cmd = fill_cmd_array(tokens, count);
+	if (!node->cmd)
+		return (free(node), NULL);
+	return (node);
+}

--- a/source/tokenizer/tokenizer.c
+++ b/source/tokenizer/tokenizer.c
@@ -6,30 +6,19 @@
 /*   By: lsadikaj <lsadikaj@student.42lausanne.ch>  +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/03/24 13:37:41 by lsadikaj          #+#    #+#             */
-/*   Updated: 2025/03/24 19:22:17 by lsadikaj         ###   ########.fr       */
+/*   Updated: 2025/03/26 15:32:29 by lsadikaj         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "../../include/minishell.h"
 
-// Check if a character is a space or tab
+// Vérifie si un caractère est un espace ou une tabulation
 int	is_space(char c)
 {
 	return (c == ' ' || c == '\t');
 }
 
-// Calculates the length of a word (non-espace characters)
-static int	word_len(char *str)
-{
-	int	len;
-
-	len = 0;
-	while (str[len] && !is_space(str[len]))
-		len++;
-	return (len);
-}
-
-// Tokenizes the input line into a linked list of tokens
+// Découpe la ligne d’entrée en une liste chaînée de tokens
 t_token	*tokenize(char *input)
 {
 	t_token			*tokens;
@@ -42,7 +31,7 @@ t_token	*tokenize(char *input)
 	{
 		if (is_space(input[i]))
 			i++;
-		else if (is_operator(&input[i]))
+		else if (is_operator_str(&input[i]))
 			i += handle_operator(&tokens, &input[i]);
 		else if (input[i] == '"' || input[i] == '\'')
 		{
@@ -52,7 +41,12 @@ t_token	*tokenize(char *input)
 			i += ret;
 		}
 		else
-			i += handle_word(&tokens, &input[i]);
+		{
+			ret = handle_word(&tokens, &input[i]);
+			if (ret <= 0)
+				return NULL;
+			i += ret;
+		}
 	}
 	return (tokens);
 }

--- a/source/tokenizer/tokenizer_handle.c
+++ b/source/tokenizer/tokenizer_handle.c
@@ -6,13 +6,13 @@
 /*   By: lsadikaj <lsadikaj@student.42lausanne.ch>  +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/03/24 17:21:49 by lsadikaj          #+#    #+#             */
-/*   Updated: 2025/03/24 19:27:36 by lsadikaj         ###   ########.fr       */
+/*   Updated: 2025/03/26 15:59:15 by lsadikaj         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "../../include/minishell.h"
 
-// Handles operator token (|, >, >>, <, <<) and adds it to the token list
+// Gère les opérateurs (|, <, >, etc.) et ajoute un token correspondant
 int	handle_operator(t_token **tokens, char *input)
 {
 	int				len;
@@ -21,36 +21,36 @@ int	handle_operator(t_token **tokens, char *input)
 
 	len = operator_length(input);
 	op = ft_substr(input, 0, len);
-	type = get_operator_type(input);
+	if (!op)
+		return (0);
+	type = get_operator_type(op);
 	add_token(tokens, op, type);
 	free(op);
 	return (len);
 }
 
-// Handles a plain word and adds it to the token list
-int	handle_word(t_token **tokens, char *input)
+// Gère un mot simple (non cité) et l’ajoute à la liste des tokens
+int handle_word(t_token **tokens, char *input)
 {
 	int		len;
 	char	*word;
 
 	len = 0;
-	while (input[len])
-	{
-		if (input[len] == ' ' || input[len] == '\t')
-			break ;
-		if (input[len] == '|' || input[len] == '<' || input[len] == '>')
-			break ;
-		if (input[len] == '\'' || input[len] == '"')
-			break ;
+	while (input[len] && !is_space(input[len]) &&
+		!is_operator_str(&input[len]) &&
+		input[len] != '"' && input[len] != '\'')
 		len++;
-	}
+	if (len <= 0)
+		return (0);
 	word = ft_substr(input, 0, len);
-	add_token(tokens. word, TOKEN_WORD);
+	if (!word)
+		return (0);
+	add_token(tokens, word, TOKEN_WORD);
 	free(word);
 	return (len);
 }
 
-// Handles a quoted string and adds it to the token list
+// Gère une chaîne entre guillemets et l’ajoute à la liste des tokens
 int	handle_quotes(t_token **tokens, char *input)
 {
 	char	quote;
@@ -64,13 +64,12 @@ int	handle_quotes(t_token **tokens, char *input)
 	if (input[len] == quote)
 	{
 		word = ft_substr(input + 1, 0, len - 1);
+		if (!word)
+			return (-1);
 		add_token(tokens, word, TOKEN_WORD);
 		free(word);
 		return (len + 1);
 	}
-	else
-	{
-		ft_printf("minishell: syntax error: unclosed quote\n");
-		return (-1);
-	}
+	ft_printf("minishell: syntax error: unclosed quote\n");
+	return (-1);
 }

--- a/source/tokenizer/tokenizer_utils.c
+++ b/source/tokenizer/tokenizer_utils.c
@@ -5,59 +5,79 @@
 /*                                                    +:+ +:+         +:+     */
 /*   By: lsadikaj <lsadikaj@student.42lausanne.ch>  +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
-/*   Created: 2025/03/24 15:58:03 by lsadikaj          #+#    #+#             */
-/*   Updated: 2025/03/24 19:29:36 by lsadikaj         ###   ########.fr       */
+/*   Created: 2025/03/26 12:03:50 by lsadikaj          #+#    #+#             */
+/*   Updated: 2025/03/26 15:32:32 by lsadikaj         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "../../include/minishell.h"
 
-// Allocates and initializes a new token
-t_token	*new_token(char *value, t_token_type type)
+// Crée un nouveau token avec une valeur et un type
+t_token *new_token(char *value, t_token_type type)
 {
-	t_token	*token;
+	t_token *token;
 
+	if (!value)
+		return (NULL);
 	token = malloc(sizeof(t_token));
 	if (!token)
 		return (NULL);
 	token->value = ft_strdup(value);
+	if (!token->value)
+		return (free(token), NULL);
 	token->type = type;
 	token->next = NULL;
 	return (token);
 }
 
-// Appends a new token to the end of the token list
-void	add_token(t_token **list, char *value, t_token_type type)
+// Ajoute un token à la fin de la liste
+void add_token(t_token **list, char *value, t_token_type type)
 {
-	t_token	*new;
-	t_token	*tmp;
-
-	new = new_token(value, type);
+	if (!value || !*value)
+		return ;
+	t_token *new = new_token(value, type);
 	if (!new)
 		return ;
 	if (!*list)
 		*list = new;
 	else
 	{
-		tmp = *list;
+		t_token *tmp = *list;
 		while (tmp->next)
 			tmp = tmp->next;
 		tmp->next = new;
 	}
 }
 
-// Returns the length of the operator (1 or 2 chars)
+// Vérifie si une chaîne commence par un opérateur
+int	is_operator_str(char *str)
+{
+	if (!str)
+		return (0);
+	if (str[0] == '|' || str[0] == '<' || str[0] == '>' || str[0] == '&')
+		return (1);
+	return (0);
+}
+
+// Retourne la longueur d'un opérateur (1 ou 2 caractères)
 int	operator_length(char *str)
 {
-	if ((str[0] == '>' && str[1] == '>') || (str[0] == '<' && str[1] == '<'))
+	if ((str[0] == '>' && str[1] == '>') ||
+		(str[0] == '<' && str[1] == '<') ||
+		(str[0] == '&' && str[1] == '&') ||
+		(str[0] == '|' && str[1] == '|'))
 		return (2);
 	return (1);
 }
 
-// Returns the operator type (PIPE, REDIR, etc.)
+// Retourne le type de token associé à un opérateur
 t_token_type	get_operator_type(char *str)
 {
-	if (str[0] == '>' && str[1] == '>')
+	if (str[0] == '&' && str[1] == '&')
+		return (TOKEN_AND);
+	else if (str[0] == '|' && str[1] == '|')
+		return (TOKEN_OR);
+	else if (str[0] == '>' && str[1] == '>')
 		return (TOKEN_APPEND);
 	else if (str[0] == '>' && str[1] != '>')
 		return (TOKEN_REDIRECT_OUT);


### PR DESCRIPTION
Cette branche ajoute l’implémentation du tokenizer et du parser pour notre minishell. Elle comprend :

- Le découpage de la ligne de commande en tokens via `tokenize()`.
- La gestion des opérateurs : `|`, `>`, `<`, `>>`, `<<`, `&&`, `||`.
- Le support des guillemets doubles (`"..."`) pour les arguments.
- La construction de l’arbre syntaxique (AST) à partir des tokens.

🔧 L'exécution réelle des commandes n'est pas encore liée à l'AST. Elle repose encore sur `ft_split()` dans `ft_read_line2()`.

⚠️ **Ce qui n’est pas encore géré** :
- Les guillemets simples (`'...'`)
- Les parenthèses pour le regroupement de commandes

---

🛠️ **Prochaine étape (nouvelle branche à venir)** :
- Gérer les guillemets simples (`'...'`) dans le tokenizer
- Puis, gérer les parenthèses (dans le tokenizer et le parser)
- Tester localement les cas avec ces nouveaux tokens